### PR TITLE
fixed task name exposed by source_distribution plugin

### DIFF
--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -629,7 +629,7 @@ Note that the `*_depends_on` methods accept the following arguments :
 
 ### Creating a source distribution
 
-*PyBuilder* can build a source distribution of your code with the plugin `source_distribution`. Activating this plugin will expose a task, `create_source_distribution`.
+*PyBuilder* can build a source distribution of your code with the plugin `source_distribution`. Activating this plugin will expose a task, `build_source_distribution`.
 
 #### Source distribution configuration
 


### PR DESCRIPTION
While following the docs, I ran into the problem where I couldn't run the `create_source_distribution` task. Seems to be because it was a typo in the docs. I fixed it, now it states `create_source_distribution` and that is the correct name of the task.