### PR TITLE
fix link to non-existing project and update to Python 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,9 +65,10 @@ title: PyBuilder an easy to use continuous build tool for Python
       </div>
       <div id="checkoutbuild">
         <pre><code>
-  git clone https://github.com/aelgru/fluentmock
-  cd fluentmock
-  virtualenv venv; source venv/bin/activate
+  git clone https://github.com/twentybn/GulpIO
+  cd GulpIO
+  python -m venv venv
+  source venv/bin/activate
   pip install pybuilder
   pyb install_dependencies
   pyb


### PR DESCRIPTION
Fixes #24 

Assuming that people are mostly on Python 3 by now, hence the creation of the virtualenv has been upgraded too.