### PR TITLE
Fix tutorial.md typo about adding tests

### DIFF
--- a/documentation/tutorial.md
+++ b/documentation/tutorial.md
@@ -153,7 +153,7 @@ Thus, we have two options:
 1. Override the coverage plugin default setting and disable failure on missing code coverage threshold.
 2. Add a test that ensures that the code is properly tested.
 
-Being a diligent responsible developer that follows 21-st century best practices we will choose the **first option**
+Being a diligent responsible developer that follows 21-st century best practices we will choose the **second option**
  and add an appropriate test.
 
 ## Writing Unit Tests


### PR DESCRIPTION
In the "Adding Python Source Files" section, towards the end when talking about test coverage, the tutorial says we have two options:

1. Override the coverage plugin default setting and disable failure on missing code coverage threshold.
2. Add a test that ensures that the code is properly tested.

Then it says: "Being a diligent responsible developer that follows 21-st century best practices we will choose the **first option** and add an appropriate test."

The option to add a test would be the second one, not the first one. I change "first option" to "second option" because that appears to be the author's original intent.